### PR TITLE
not raise against NEVER_UNPERMITTED_PARAMS

### DIFF
--- a/test/raise_on_unpermitted_params_test.rb
+++ b/test/raise_on_unpermitted_params_test.rb
@@ -30,4 +30,16 @@ class RaiseOnUnpermittedParamsTest < ActiveSupport::TestCase
       params.permit(:book => [:pages])
     end
   end
+  
+  test "not raise on params included in NEVER_UNPERMITTED_PARAMS" do
+    # NEVER_UNPERMITTED_PARAMS = %w( controller action )
+    key = ActionController::Parameters::NEVER_UNPERMITTED_PARAMS.sample
+    params = ActionController::Parameters.new({
+      key => "Turnips"
+    })
+
+    assert_nothing_raised(ActionController::UnpermittedParameters) do
+      params.permit()
+    end
+  end
 end


### PR DESCRIPTION
Tests that any param included in `Parameters::NEVER_UNPERMITTED_PARAMS` will not raise an error even if not explicitly permitted.
